### PR TITLE
Updates to Wallet Download Links

### DIFF
--- a/index.html
+++ b/index.html
@@ -701,16 +701,16 @@
                 <div class="row">
                     <div class="col-sm-3">
                         <div class="item">
-                            <a href="https://github.com/hushmate/HUSHmate-swing-wallet/releases" target="_blank">
+                            <a href="https://github.com/MyHush/SilentDragonLite/releases" target="_blank">
                                 <!----<a style="pointer-events: none; cursor: default;" href="" target="_blank" -->
                                 <i class="fa fa-linux"></i>
-                                <h4 class="stoolst1lang">Linux Wallet</h4>
+                                <h4 class="stoolst1lang">Linux Lite Wallet</h4>
                             </a>
                         </div>
                     </div>
                     <div class="col-sm-3">
                         <div class="item">
-                            <a href="https://github.com/hushmate/HUSHmate-swing-wallet/releases" target="_blank">
+                            <a href="https://github.com/MyHush/SilentDragon/releases" target="_blank">
                                 <i class="fa fa-windows"></i>
                                 <h4 class="stoolst2lang">Windows Wallet</h4>
                             </a>
@@ -718,7 +718,7 @@
                     </div>
                     <div class="col-sm-3">
                         <div class="item">
-                            <a href="https://github.com/hushmate/HUSHmate-swing-wallet/releases" target="_blank">
+                            <a href="https://github.com/MyHush/SilentDragon/releases" target="_blank">
                                 <i class="fa fa-apple"></i>
                                 <h4 class="stoolst3lang">Mac OS Wallet</h4>
                             </a>


### PR DESCRIPTION
Update wallet download links for Linux, Windows and Mac OS.
And a change of name for Linux wallet to Lite Wallet since that is the only release available currently available for Linux.